### PR TITLE
Add a run method to the Stub

### DIFF
--- a/fetchy-api/src/main/java/org/irenical/fetchy/service/Stub.java
+++ b/fetchy-api/src/main/java/org/irenical/fetchy/service/Stub.java
@@ -25,5 +25,7 @@ public interface Stub<IFACE> extends LifeCycle {
     }
 
     <OUTPUT,ERROR extends Exception> OUTPUT call(ServiceCall<IFACE,OUTPUT,ERROR> callable) throws ERROR;
+
+    <ERROR extends Exception> void run(ServiceRun<IFACE, ERROR> callable) throws ERROR;
     
 }

--- a/fetchy-api/src/main/java/org/irenical/fetchy/service/factory/ServiceDiscoveryExecutor.java
+++ b/fetchy-api/src/main/java/org/irenical/fetchy/service/factory/ServiceDiscoveryExecutor.java
@@ -37,6 +37,21 @@ public abstract class ServiceDiscoveryExecutor<IFACE,CLIENT extends IFACE> imple
     }
 
     @Override
+    public <ERROR extends Exception> void run(ServiceRun<IFACE, ERROR> callable) throws ERROR {
+        CLIENT clientInstance = null;
+        try {
+            clientInstance = create();
+            if ( clientInstance == null ) {
+                throw new RuntimeException( "Unable to instantiate a new client" );
+            }
+            onBeforeExecute( clientInstance );
+            callable.run( (IFACE) clientInstance );
+        } finally {
+            onAfterExecute( clientInstance );
+        }
+    }
+
+    @Override
     public void start() throws Exception {
 
     }


### PR DESCRIPTION
This allows methods to be called on stubs while ignoring the return value.

Example:

``` java
stub.run( client -> client.doStuff() );
```
