### PR TITLE
Cache jersey2 client connections

### DIFF
--- a/fetchy-jersey2/src/main/java/org/irenical/fetchy/executor/jersey2/Jersey2ServiceExecutor.java
+++ b/fetchy-jersey2/src/main/java/org/irenical/fetchy/executor/jersey2/Jersey2ServiceExecutor.java
@@ -11,15 +11,26 @@ import javax.ws.rs.client.WebTarget;
 
 public class Jersey2ServiceExecutor extends ServiceDiscoveryExecutor<WebTarget,WebTarget> {
 
+    private Client client;
+    private String address;
+
     public Jersey2ServiceExecutor(String serviceId) {
         super( serviceId );
     }
 
     @Override
     protected WebTarget newInstance(ServiceNode serviceNode) throws Exception {
-        Client client = ClientBuilder.newBuilder()
-                .register(JacksonFeature.class)
-                .build();
+        if ( address == null || !serviceNode.getAddress().equals(address) ) {
+            address = serviceNode.getAddress();
+
+            disposeClient();
+        }
+
+        if ( client == null ) {
+            client = ClientBuilder.newBuilder()
+                    .register(JacksonFeature.class)
+                    .build();
+        }
 
         return client.target(serviceNode.getAddress());
     }
@@ -34,4 +45,17 @@ public class Jersey2ServiceExecutor extends ServiceDiscoveryExecutor<WebTarget,W
 
     }
 
+    @Override
+    public void stop() throws Exception {
+        super.stop();
+
+        disposeClient();
+    }
+
+    private void disposeClient() {
+        if (client != null) {
+            client.close();
+            client = null;
+        }
+    }
 }


### PR DESCRIPTION
As per the jersey documentation:

``` java
/**
 * Clients are heavy-weight objects that manage the client-side communication
 * infrastructure. Initialization as well as disposal of a {@code Client} instance
 * may be a rather expensive operation. It is therefore advised to construct only
 * a small number of {@code Client} instances in the application. Client instances
 * must be {@link #close() properly closed} before being disposed to avoid leaking
 * resources.
 */
```
