### PR TITLE
Cache the instance of OKHttpClient in fetchy-retrofit

### DIFF
--- a/fetchy-retrofit/src/main/java/org/irenical/fetchy/executor/retrofit/RetrofitServiceExecutor.java
+++ b/fetchy-retrofit/src/main/java/org/irenical/fetchy/executor/retrofit/RetrofitServiceExecutor.java
@@ -23,18 +23,17 @@ public class RetrofitServiceExecutor<IFACE> extends ServiceDiscoveryExecutor<IFA
     @Override
     protected IFACE newInstance(ServiceNode serviceNode) throws Exception {
 
-        Retrofit.Builder builder = new Retrofit.Builder()
-                .baseUrl( serviceNode.getAddress() );
-
-        if ( httpClient != null ) {
-            builder.client( httpClient );
+        if ( httpClient == null ) {
+            httpClient = new OkHttpClient();
         }
 
-        builder.addCallAdapterFactory( RxJavaCallAdapterFactory.create() );
+        Retrofit retrofit = new Retrofit.Builder()
+                .baseUrl( serviceNode.getAddress() )
+                .client( httpClient )
+                .addCallAdapterFactory( RxJavaCallAdapterFactory.create() )
+                .addConverterFactory( MoshiConverterFactory.create() )
+                .build();
 
-        builder.addConverterFactory( MoshiConverterFactory.create() );
-
-        Retrofit retrofit = builder.build();
         return retrofit.create( ifaceClass );
     }
 


### PR DESCRIPTION
Every time a new retrofit instance is built with the default settings a new instance of OKHttpClient is built as well. That means that a new threadpool is instanced to handle requests leading to the JVM eventually reaching its thread count limit.

Caching the client should prevent the issue.
