### PR TITLE
Add a simple Jindy property-based discoverer

### DIFF
--- a/fetchy-discoverer-jindy/pom.xml
+++ b/fetchy-discoverer-jindy/pom.xml
@@ -1,0 +1,39 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.irenical.fetchy</groupId>
+    <artifactId>fetchy</artifactId>
+    <version>2.0.1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>fetchy-discoverer-jindy</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Fetchy Jindy Discoverer</name>
+  <description>Fetchy Jindy - property-based Jindy service discovery implementation</description>
+
+  <developers>
+    <developer>
+      <name>Luis Nabais</name>
+      <email>dextro@gmail.com</email>
+    </developer>
+  </developers>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.irenical.fetchy</groupId>
+      <artifactId>fetchy-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.irenical.jindy</groupId>
+      <artifactId>jindy-api</artifactId>
+      <version>2.1.0</version>
+    </dependency>
+  </dependencies>
+
+</project>
+

--- a/fetchy-discoverer-jindy/src/main/java/org/irenical/fetchy/discoverer/jindy/JindyPropertyDiscoverer.java
+++ b/fetchy-discoverer-jindy/src/main/java/org/irenical/fetchy/discoverer/jindy/JindyPropertyDiscoverer.java
@@ -1,0 +1,57 @@
+package org.irenical.fetchy.discoverer.jindy;
+
+import org.irenical.fetchy.Node;
+import org.irenical.fetchy.discoverer.DiscoverException;
+import org.irenical.fetchy.discoverer.Discoverer;
+import org.irenical.jindy.Config;
+import org.irenical.jindy.ConfigFactory;
+
+import java.util.Collections;
+import java.util.List;
+
+public class JindyPropertyDiscoverer implements Discoverer {
+
+    private final Config config;
+    private final String addressProperty;
+    private final String portProperty;
+
+    public JindyPropertyDiscoverer(String addressProperty) {
+        this(ConfigFactory.getConfig(), addressProperty, null);
+    }
+
+    public JindyPropertyDiscoverer(String addressProperty, String portProperty) {
+        this(ConfigFactory.getConfig(), addressProperty, portProperty);
+    }
+
+    public JindyPropertyDiscoverer(Config config, String addressProperty) {
+        this(config, addressProperty, null);
+    }
+
+    public JindyPropertyDiscoverer(Config config, String addressProperty, String portProperty) {
+        this.config = config;
+        this.addressProperty = addressProperty;
+        this.portProperty = portProperty;
+    }
+
+    @Override
+    public List<Node> discover(String s) throws DiscoverException {
+        String address = config.getString(addressProperty);
+
+        if (address == null || address.trim().isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        Node node = new Node(address);
+
+        if (portProperty != null) {
+            final int port = config.getInt(portProperty, -1);
+
+            if (port > -1) {
+                node.setPort(port);
+            }
+        }
+
+        return Collections.singletonList(node);
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
   <modules>
     <module>fetchy-api</module>
     <module>fetchy-discoverer-consul</module>
+    <module>fetchy-discoverer-jindy</module>
     <module>fetchy-balancer-random</module>
     <module>fetchy-connector-retrofit</module>
     <module>fetchy-connector-jersey2</module>


### PR DESCRIPTION
Add a simple discoverer that reads a pair of properties from jindy (address and port) and constructs a single node from them.

Example usage:

```java
Discoverer discoverer = new JindyDiscoverer(ConfigFactory.getConfig().prefix("service"), "address.property", "port.property");
fetchy.register("service", discoverer, balancer, connector);
```