### PR TITLE
Remove JacksonFeature from the Jersey Connector

### DIFF
--- a/fetchy-connector-jersey2/pom.xml
+++ b/fetchy-connector-jersey2/pom.xml
@@ -32,11 +32,6 @@
 			<artifactId>jersey-client</artifactId>
 			<version>2.25.1</version>
 		</dependency>
-		<dependency>
-			<groupId>org.glassfish.jersey.media</groupId>
-			<artifactId>jersey-media-json-jackson</artifactId>
-			<version>2.25.1</version>
-		</dependency>
 	</dependencies>
 
 </project>

--- a/fetchy-connector-jersey2/src/main/java/org/irenical/fetchy/connector/jersey2/Jersey2Connector.java
+++ b/fetchy-connector-jersey2/src/main/java/org/irenical/fetchy/connector/jersey2/Jersey2Connector.java
@@ -1,6 +1,5 @@
 package org.irenical.fetchy.connector.jersey2;
 
-import org.glassfish.jersey.jackson.JacksonFeature;
 import org.irenical.fetchy.Node;
 import org.irenical.fetchy.connector.ConnectException;
 import org.irenical.fetchy.connector.Connector;
@@ -38,7 +37,6 @@ public class Jersey2Connector implements Connector<WebTarget>, LifeCycle {
   public Stub<WebTarget> connect(Node node) throws ConnectException {
     if (client == null) {
       ClientBuilder builder = ClientBuilder.newBuilder();
-      builder.register(JacksonFeature.class);
 
       if (clientConfigurator != null) {
         clientConfigurator.accept( builder );

--- a/fetchy-connector-jersey2/src/test/java/org/irenical/fetchy/connector/jersey2/Jersey2ConnectorTest.java
+++ b/fetchy-connector-jersey2/src/test/java/org/irenical/fetchy/connector/jersey2/Jersey2ConnectorTest.java
@@ -1,6 +1,5 @@
 package org.irenical.fetchy.connector.jersey2;
 
-import org.glassfish.jersey.jackson.JacksonFeature;
 import org.irenical.fetchy.Node;
 import org.irenical.fetchy.connector.Stub;
 import org.junit.Assert;
@@ -19,9 +18,10 @@ public class Jersey2ConnectorTest {
     public void testNoClientConfigurator() throws Exception {
         Jersey2Connector connector = new Jersey2Connector();
 
-        Stub<WebTarget> connect = connector.connect(new Node( "localhost", 1337 ) );
+        Stub<WebTarget> connect = connector.connect(new Node( "http://localhost", 1337 ) );
 
-        Assert.assertTrue( connect.get().getConfiguration().isRegistered( JacksonFeature.class ) );
+        Assert.assertEquals( "localhost", connect.get().getUri().getHost() );
+        Assert.assertEquals( 1337, connect.get().getUri().getPort() );
     }
 
     @Test


### PR DESCRIPTION
Removing the JacksonFeature dependency as discussed in issue #14 