### PR TITLE
Fix handling of missing node address protocol in the jersey2 connector

### DIFF
--- a/fetchy-connector-jersey2/src/main/java/org/irenical/fetchy/connector/jersey2/Jersey2Connector.java
+++ b/fetchy-connector-jersey2/src/main/java/org/irenical/fetchy/connector/jersey2/Jersey2Connector.java
@@ -14,6 +14,8 @@ import java.util.function.Consumer;
 
 public class Jersey2Connector implements Connector<WebTarget>, LifeCycle {
 
+  static final String DEFAULT_SCHEME = "http";
+
   private Client client;
 
   private boolean isRunning = false;
@@ -45,7 +47,13 @@ public class Jersey2Connector implements Connector<WebTarget>, LifeCycle {
       client = builder.build();
     }
 
-    UriBuilder uriBuilder = UriBuilder.fromUri(node.getAddress());
+    UriBuilder uriBuilder;
+
+    if (node.getAddress().matches("(\\w+)?\\:?\\/\\/.*")) {
+      uriBuilder = UriBuilder.fromUri(node.getAddress());
+    } else {
+      uriBuilder = UriBuilder.fromUri(DEFAULT_SCHEME + "://" + node.getAddress());
+    }
 
     if (node.getPort() != null) {
       uriBuilder = uriBuilder.port(node.getPort());

--- a/fetchy-connector-jersey2/src/test/java/org/irenical/fetchy/connector/jersey2/Jersey2ConnectorTest.java
+++ b/fetchy-connector-jersey2/src/test/java/org/irenical/fetchy/connector/jersey2/Jersey2ConnectorTest.java
@@ -18,8 +18,9 @@ public class Jersey2ConnectorTest {
     public void testNoClientConfigurator() throws Exception {
         Jersey2Connector connector = new Jersey2Connector();
 
-        Stub<WebTarget> connect = connector.connect(new Node( "http://localhost", 1337 ) );
+        Stub<WebTarget> connect = connector.connect(new Node( "https://localhost", 1337 ) );
 
+        Assert.assertEquals( "https", connect.get().getUri().getScheme() );
         Assert.assertEquals( "localhost", connect.get().getUri().getHost() );
         Assert.assertEquals( 1337, connect.get().getUri().getPort() );
     }
@@ -43,4 +44,14 @@ public class Jersey2ConnectorTest {
         Mockito.verify( clientConfiguratorSpy, times( 1 ) ).accept( Mockito.any() );
     }
 
+    @Test
+    public void testWithMissingProtocolInAddress() {
+      Jersey2Connector connector = new Jersey2Connector();
+
+      Stub<WebTarget> connect = connector.connect(new Node( "localhost", 1337 ) );
+
+      Assert.assertEquals( Jersey2Connector.DEFAULT_SCHEME, connect.get().getUri().getScheme() );
+      Assert.assertEquals( "localhost", connect.get().getUri().getHost() );
+      Assert.assertEquals( 1337, connect.get().getUri().getPort() );
+    }
 }


### PR DESCRIPTION
There's an issue with the Jersey2 connector when the discoverer provides an address with no scheme included.

Due to the way the Java UriBuilder class works the connector fails to build the proper address despite being perfectly acceptable to assume HTTP as the scheme.